### PR TITLE
Overlay proposed changes and bugfixes

### DIFF
--- a/src/inject/app/AdOverlayComponent.tsx
+++ b/src/inject/app/AdOverlayComponent.tsx
@@ -40,6 +40,7 @@ const AdOverlayComponent = ({ elementId, winningCPM, winningBidder, currency, ti
           backgroundColor: 'primary.light',
           color: 'text.primary',
           padding: 0.5,
+          boxSizing: 'border-box',
           flexGrow: 1,
           '&:hover': { opacity: 1 },
           display: 'flex',
@@ -59,8 +60,8 @@ const AdOverlayComponent = ({ elementId, winningCPM, winningBidder, currency, ti
               inPopOver={false}
             />
           </Grid>
-          {expanded && (currency || winningBidder || winningCPM || timeToRespond) && (
-            <Grid container item xs={12} spacing={1}>
+          {expanded && (currency || winningBidder || winningCPM || timeToRespond || elementId) && (
+            <Grid container item xs={12} spacing={.5} p={.5} sx={{paddingTop: '0px !important'}}>
               {winningCPM && (
                 <Grid item>
                   <Paper elevation={1} sx={{ p: 0.5 }}>
@@ -70,33 +71,30 @@ const AdOverlayComponent = ({ elementId, winningCPM, winningBidder, currency, ti
                     </Typography>
                   </Paper>
                 </Grid>
-              )}
-              {winningBidder && (
-                <Grid item>
-                  <Paper elevation={1} sx={{ p: 0.5 }}>
-                    <Typography>
-                      <strong>Bidder: </strong>
-                      {winningBidder}
-                    </Typography>
-                  </Paper>
-                </Grid>
-              )}
-              {timeToRespond && (
-                <Grid item>
-                  <Paper elevation={1} sx={{ p: 0.5 }}>
-                    <Typography>
-                      <strong>TTR: </strong>
-                      {timeToRespond}ms
-                    </Typography>
-                  </Paper>
-                </Grid>
-              )}
-            </Grid>
-          )}
-
-          {expanded && elementId && (
-            <Grid container item xs={12} spacing={1}>
-              <GamDetailsComponent elementId={elementId} inPopOver={false} />
+             )}
+             {winningBidder && (
+               <Grid item>
+                 <Paper elevation={1} sx={{ p: 0.5 }}>
+                   <Typography>
+                     <strong>Bidder: </strong>
+                     {winningBidder}
+                   </Typography>
+                 </Paper>
+               </Grid>
+             )}
+             {timeToRespond && (
+               <Grid item>
+                 <Paper elevation={1} sx={{ p: 0.5 }}>
+                   <Typography>
+                     <strong>TTR: </strong>
+                     {timeToRespond}ms
+                   </Typography>
+                 </Paper>
+               </Grid>
+             )}
+             {elementId && (
+               <GamDetailsComponent elementId={elementId} inPopOver={false} />
+             )}
             </Grid>
           )}
         </Grid>

--- a/src/inject/app/GamDetailsComponent.tsx
+++ b/src/inject/app/GamDetailsComponent.tsx
@@ -20,7 +20,7 @@ const GamDetailsComponent = ({ elementId, inPopOver }: IGamDetailComponentProps)
     if (googletag && typeof googletag?.pubads === 'function') {
       const pubads = googletag.pubads();
       const slots = pubads.getSlots();
-      const slot = slots.find((slot) => slot.getSlotElementId() === elementId);
+      const slot = slots.find((slot) => slot.getAdUnitPath() === elementId);
       if (slot) {
         setSlotElementId(slot.getSlotElementId());
         setSlotAdUnitPath(slot.getAdUnitPath());
@@ -52,10 +52,8 @@ const GamDetailsComponent = ({ elementId, inPopOver }: IGamDetailComponentProps)
       {lineItemId && (
         <Grid item>
           <Paper elevation={1} sx={{ p: inPopOver ? 1 : 0.5 }}>
-            <Typography component={'span'} variant="h4">
-              LineItem-ID:{' '}
-            </Typography>
-            <Typography component={'span'} variant="body1" sx={{ '& a': { color: 'secondary.main' } }}>
+            <Typography sx={{ '& a': { color: 'secondary.main', fontSize: 12 } }}>
+              <strong>LineItem: </strong>
               <a
                 href={`https://admanager.google.com/${networktId}#delivery/LineItemDetail/lineItemId=${lineItemId}`}
                 rel="noreferrer"
@@ -71,10 +69,8 @@ const GamDetailsComponent = ({ elementId, inPopOver }: IGamDetailComponentProps)
       {creativeId && (
         <Grid item>
           <Paper elevation={1} sx={{ p: inPopOver ? 1 : 0.5 }}>
-            <Typography variant="h4" component={'span'}>
-              Creative-ID:{' '}
-            </Typography>
-            <Typography component={'span'} variant="body1" sx={{ '& a': { color: 'secondary.main' } }}>
+            <Typography sx={{ '& a': { color: 'secondary.main', fontSize: 12 } }}>
+              <strong>Creative: </strong>
               <a
                 href={`https://admanager.google.com/${networktId}#delivery/CreativeDetail/creativeId=${creativeId}`}
                 rel="noreferrer"
@@ -90,10 +86,8 @@ const GamDetailsComponent = ({ elementId, inPopOver }: IGamDetailComponentProps)
       {slotAdUnitPath && (
         <Grid item>
           <Paper elevation={1} sx={{ p: inPopOver ? 1 : 0.5 }}>
-            <Typography variant="h4" component={'span'}>
-              AdUnit Path:{' '}
-            </Typography>
-            <Typography variant="body1" component={'span'}>
+            <Typography>
+              <strong>AdUnit: </strong>
               {slotAdUnitPath}
             </Typography>
           </Paper>
@@ -103,10 +97,8 @@ const GamDetailsComponent = ({ elementId, inPopOver }: IGamDetailComponentProps)
       {slotElementId && (
         <Grid item>
           <Paper elevation={1} sx={{ p: inPopOver ? 1 : 0.5 }}>
-            <Typography variant="h4" component={'span'}>
-              Element-ID:{' '}
-            </Typography>
-            <Typography variant="body1" component={'span'}>
+            <Typography>
+              <strong>Element: </strong>
               {slotElementId}
             </Typography>
           </Paper>


### PR DESCRIPTION
CC @florianerl 

Made some changes tightening up styling so that all the gam details fit better in smaller height ad sizes like 728x90's

Also fixed the bug where if a divid is overridden for the slot, it wouldn't show the GAM details.

Before: 
![Screen Shot on 2022-05-21 at 15-55-59](https://user-images.githubusercontent.com/707699/169671541-96eab17a-08f5-435e-af97-70e6d5aafd7a.png)

After:
![Screen Shot on 2022-05-21 at 15-54-05](https://user-images.githubusercontent.com/707699/169671549-a36141de-0dde-4f01-be02-b7e1d1d5df37.png)

