### PR TITLE
added debounce hook and refactored the network inspector tool a bit

### DIFF
--- a/src/pages/Background/background.ts
+++ b/src/pages/Background/background.ts
@@ -119,13 +119,13 @@ export interface ITabInfo {
   namespace?: string;
   updateNamespace?: (namespace: string) => void;
   syncState?: string;
-  initReqChainData?: InitReqChainData;
+  initReqChainResult?: initReqChainResult;
 }
 
 export interface ITabInfos {
   [key: number]: ITabInfo;
 }
 
-export interface InitReqChainData {
+export interface initReqChainResult {
   [key: string]: any;
 }

--- a/src/pages/Shared/components/initiator/InitiatorComponent.tsx
+++ b/src/pages/Shared/components/initiator/InitiatorComponent.tsx
@@ -9,6 +9,7 @@ import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import JSONViewerComponent from '../JSONViewerComponent';
 import AppStateContext from '../../contexts/appStateContext';
+import InspectedPageContext from '../../contexts/inspectedPageContext';
 import Grid from '@mui/material/Grid';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import './InitiatorComponent.css';
@@ -24,7 +25,8 @@ const gridStyle = {
 };
 
 const InitiatorComponent = (): JSX.Element => {
-  const { initReqChainResult, isRefresh, initDataLoaded, setInitDataLoaded } = useContext(AppStateContext);
+  const { isRefresh, initDataLoaded, setInitDataLoaded } = useContext(AppStateContext);
+  const { initReqChainResult } = useContext(InspectedPageContext);
   const [initChainFeatureStatus, setInitChainFeatureStatus] = useState<boolean>(null);
   const [rootUrl, setRootUrl] = useState<string>('');
   const [showReqChain, setShowReqChain] = useState<boolean>(false);
@@ -123,10 +125,11 @@ const InitiatorComponent = (): JSX.Element => {
               Set URL
             </Button>
           </div>
-          <div className={`initiator__output ${(showReqChain || initDataLoaded) && initReqChainResult && Object.keys(initReqChainResult).length > 0 ? 'initiator__output-left-align' : ''}`}>
+            <div className={`initiator__output ${(showReqChain || initDataLoaded) && initReqChainResult && Object.keys(initReqChainResult).length > 0 ? 'initiator__output-left-align' : ''}`}>
             {(showReqChain || initDataLoaded) && initReqChainResult && Object.keys(initReqChainResult).length > 0
               ? (
                   <JSONViewerComponent
+                    // src={initReqChainResult}
                     src={initReqChainResult}
                     name={false}
                     collapsed={2}

--- a/src/pages/Shared/components/initiator/InitiatorComponent.tsx
+++ b/src/pages/Shared/components/initiator/InitiatorComponent.tsx
@@ -129,7 +129,6 @@ const InitiatorComponent = (): JSX.Element => {
             {(showReqChain || initDataLoaded) && initReqChainResult && Object.keys(initReqChainResult).length > 0
               ? (
                   <JSONViewerComponent
-                    // src={initReqChainResult}
                     src={initReqChainResult}
                     name={false}
                     collapsed={2}

--- a/src/pages/Shared/components/initiator/InitiatorComponent.tsx
+++ b/src/pages/Shared/components/initiator/InitiatorComponent.tsx
@@ -24,7 +24,7 @@ const gridStyle = {
 };
 
 const InitiatorComponent = (): JSX.Element => {
-  const { initiatorOutput, isRefresh, initDataLoaded, setInitDataLoaded } = useContext(AppStateContext);
+  const { initReqChainResult, isRefresh, initDataLoaded, setInitDataLoaded } = useContext(AppStateContext);
   const [initChainFeatureStatus, setInitChainFeatureStatus] = useState<boolean>(null);
   const [rootUrl, setRootUrl] = useState<string>('');
   const [showReqChain, setShowReqChain] = useState<boolean>(false);
@@ -98,26 +98,9 @@ const InitiatorComponent = (): JSX.Element => {
           <Typography paragraph>
             Note: It is advised when testing User Sync URL's that you clear cookies relative to the domain you are testing. This will ensure that results are in-line with an initial visit to the current page. Additionally, the first resource matching the root URL will be used to generate the initiator request chain.
           </Typography>
-          <ol>
-            <li>
-              <Typography>Enable the feature by sliding the toggle below.</Typography>
-            </li>
-            <li>
-              <Typography>Enter a root URL to listen for as the page loads to generate a request chain from, then click the "Set URL" button. For example, <em>https://ads.pubmatic.com/AdServer/js/user_sync.html?kdntuid=1&p=159096&us_privacy=1YNY</em></Typography>
-            </li>
-            <li>
-              <Typography>
-                Close this window, re-open the Chrome Dev Tools again and navigate back to Professor Prebid --&gt; Network Inspector
-              </Typography>
-            </li>
-            <li className="refresh-icon__list-item">
-              <Typography component={'span'} className="initiator__flex-parent">
-                Lastly, click the{' '}
-                <RefreshIcon />
-                icon (top-right). This will refresh the page and generate a new initiator request chain below (If one is present for the provided Root URL).
-              </Typography>
-            </li>
-          </ol>
+          <Typography paragraph>
+            View instructions on the Prebid documentation site <a href="https://docs.prebid.org/tools/professor-prebid.html" target="_blank" rel="noreferrer">here</a>.
+          </Typography>
           <br />
           <br />
           <div className="initiator-form">
@@ -140,11 +123,11 @@ const InitiatorComponent = (): JSX.Element => {
               Set URL
             </Button>
           </div>
-          <div className={`initiator__output ${(showReqChain || initDataLoaded) && initiatorOutput && Object.keys(initiatorOutput).length > 0 ? 'initiator__output-left-align' : ''}`}>
-            {(showReqChain || initDataLoaded) && initiatorOutput && Object.keys(initiatorOutput).length > 0
+          <div className={`initiator__output ${(showReqChain || initDataLoaded) && initReqChainResult && Object.keys(initReqChainResult).length > 0 ? 'initiator__output-left-align' : ''}`}>
+            {(showReqChain || initDataLoaded) && initReqChainResult && Object.keys(initReqChainResult).length > 0
               ? (
                   <JSONViewerComponent
-                    src={initiatorOutput}
+                    src={initReqChainResult}
                     name={false}
                     collapsed={2}
                     displayObjectSize={true}

--- a/src/pages/Shared/contexts/appStateContext.tsx
+++ b/src/pages/Shared/contexts/appStateContext.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useContext, useEffect } from 'react';
 import { useMediaQuery, useTheme } from '@mui/material';
 import InspectedPageContext from './inspectedPageContext';
+import { useDebounce } from '../hooks/useDebounce';
 import {
   IPrebidDetails,
   IPrebidAuctionInitEventData,
@@ -32,6 +33,7 @@ const AppStateContext = React.createContext<AppState>({
   setIsRefresh: () => {},
   initDataLoaded: false,
   setInitDataLoaded: () => {},
+  initReqChainResult: {},
 });
 
 export const StateContextProvider = ({ children }: StateContextProviderProps) => {
@@ -52,6 +54,7 @@ export const StateContextProvider = ({ children }: StateContextProviderProps) =>
   const [initiatorOutput, setInitiatorOutput] = useState<any>({});
   const [isRefresh, setIsRefresh] = useState<boolean>(false);
   const [initDataLoaded, setInitDataLoaded] = useState<boolean>(false);
+  const initReqChainResult = useDebounce(initiatorOutput, 2000);
   
   useEffect(() => {
     if (pbjsNamespace === undefined && prebids && Object.keys(prebids).length > 0) {
@@ -123,6 +126,7 @@ export const StateContextProvider = ({ children }: StateContextProviderProps) =>
     setIsRefresh,
     initDataLoaded,
     setInitDataLoaded,
+    initReqChainResult,
   };
 
   return <AppStateContext.Provider value={contextValue}>{children}</AppStateContext.Provider>;
@@ -153,6 +157,9 @@ interface AppState {
   setIsRefresh: React.Dispatch<React.SetStateAction<boolean>>;
   initDataLoaded: boolean;
   setInitDataLoaded: React.Dispatch<React.SetStateAction<boolean>>;
+  initReqChainResult: {
+    [key: string]: any;
+  };
 }
 
 interface StateContextProviderProps {

--- a/src/pages/Shared/contexts/appStateContext.tsx
+++ b/src/pages/Shared/contexts/appStateContext.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useContext, useEffect } from 'react';
 import { useMediaQuery, useTheme } from '@mui/material';
 import InspectedPageContext from './inspectedPageContext';
-import { useDebounce } from '../hooks/useDebounce';
+
 import {
   IPrebidDetails,
   IPrebidAuctionInitEventData,
@@ -33,7 +33,6 @@ const AppStateContext = React.createContext<AppState>({
   setIsRefresh: () => {},
   initDataLoaded: false,
   setInitDataLoaded: () => {},
-  initReqChainResult: {},
 });
 
 export const StateContextProvider = ({ children }: StateContextProviderProps) => {
@@ -48,13 +47,12 @@ export const StateContextProvider = ({ children }: StateContextProviderProps) =>
   const [auctionEndEvents, setAuctionEndEvents] = useState<IPrebidAuctionEndEventData[]>([]);
   const [allWinningBids, setAllWinningBids] = React.useState<IPrebidBidWonEventData[]>([]);
   const [adsRendered, setAdsRendered] = React.useState<IPrebidAdRenderSucceededEventData[]>([]);
-  const { prebids, initReqChainData } = useContext(InspectedPageContext);
+  const { prebids } = useContext(InspectedPageContext);
   const isSmallScreen = useMediaQuery(useTheme().breakpoints.down('sm'));
   const isPanel = useMediaQuery(useTheme().breakpoints.up('md'));
   const [initiatorOutput, setInitiatorOutput] = useState<any>({});
   const [isRefresh, setIsRefresh] = useState<boolean>(false);
   const [initDataLoaded, setInitDataLoaded] = useState<boolean>(false);
-  const initReqChainResult = useDebounce(initiatorOutput, 2000);
   
   useEffect(() => {
     if (pbjsNamespace === undefined && prebids && Object.keys(prebids).length > 0) {
@@ -63,11 +61,6 @@ export const StateContextProvider = ({ children }: StateContextProviderProps) =>
       setPbjsNamespace(newValue);
     }
   }, [pbjsNamespace, prebids, setPbjsNamespace]);
-
-  useEffect(() => {
-    const reqChainData = JSON.parse(initReqChainData?.initReqChain || '{}');
-    setInitiatorOutput(reqChainData);
-  }, [initReqChainData]);
 
   useEffect(() => {
     const prebid = prebids?.[pbjsNamespace] || ({} as IPrebidDetails);
@@ -126,7 +119,6 @@ export const StateContextProvider = ({ children }: StateContextProviderProps) =>
     setIsRefresh,
     initDataLoaded,
     setInitDataLoaded,
-    initReqChainResult,
   };
 
   return <AppStateContext.Provider value={contextValue}>{children}</AppStateContext.Provider>;
@@ -157,9 +149,6 @@ interface AppState {
   setIsRefresh: React.Dispatch<React.SetStateAction<boolean>>;
   initDataLoaded: boolean;
   setInitDataLoaded: React.Dispatch<React.SetStateAction<boolean>>;
-  initReqChainResult: {
-    [key: string]: any;
-  };
 }
 
 interface StateContextProviderProps {

--- a/src/pages/Shared/contexts/inspectedPageContext.tsx
+++ b/src/pages/Shared/contexts/inspectedPageContext.tsx
@@ -1,7 +1,8 @@
 import React, { createContext, useEffect, useState, useCallback } from 'react';
-import { ITabInfo, ITabInfos, InitReqChainData } from '../../Background/background';
+import { ITabInfo, ITabInfos, initReqChainResult } from '../../Background/background';
 import { getTabId, sendChromeTabsMessage } from '../../Shared/utils';
 import { DOWNLOAD_FAILED } from '../constants';
+import { useDebounce } from '../hooks/useDebounce';
 
 const InspectedPageContext = createContext<ITabInfo | undefined>(undefined);
 
@@ -13,7 +14,8 @@ export const InspectedPageContextProvider = ({ children }: ChromeStorageProvider
   const [pageContext, setPageContext] = useState<ITabInfo>({});
   const [downloading, setDownloading] = useState<'true' | 'false' | 'error'>('false');
   const [syncInfo, setSyncInfo] = useState<string>('');
-  const [initReqChainData, setInitReqChainData] = useState<InitReqChainData>({});
+  const [initReqChainData, setInitReqChainData] = useState<initReqChainResult>({});
+  const initReqChainResult = useDebounce(initReqChainData, 2000);
 
   const fetchEvents = useCallback(async (tabInfos: ITabInfos) => {
     const tabId = await getTabId();
@@ -58,10 +60,6 @@ export const InspectedPageContextProvider = ({ children }: ChromeStorageProvider
         const tabInfoWithEvents = await fetchEvents({ ...changes.tabInfos.newValue });
         setPageContext(tabInfoWithEvents);
       }
-
-      if (areaName === 'local' && changes.initReqChain && changes) {
-        setInitReqChainData({ initReqChain: changes.initReqChain.newValue });
-      }
     };
     chrome.storage.onChanged.addListener(handler);
 
@@ -71,7 +69,22 @@ export const InspectedPageContextProvider = ({ children }: ChromeStorageProvider
     };
   }, [fetchEvents]);
 
-  const contextValue: ITabInfo = { ...pageContext, downloading, syncState: syncInfo, initReqChainData };
+  useEffect(() => {
+    // Subscribe to changes in local storage
+    const handler = async (changes: any, areaName: 'sync' | 'local' | 'managed') => {
+      if (areaName === 'local' && changes.initReqChain && changes) {
+        setInitReqChainData(JSON.parse(changes.initReqChain.newValue));
+      }
+    };
+    chrome.storage.onChanged.addListener(handler);
+
+    // Unsubscribe when component unmounts
+    return () => {
+      chrome.storage.onChanged.removeListener(handler);
+    };
+  }, []);
+
+  const contextValue: ITabInfo = { ...pageContext, downloading, syncState: syncInfo, initReqChainResult };
 
   return <InspectedPageContext.Provider value={contextValue}>{children}</InspectedPageContext.Provider>;
 };

--- a/src/pages/Shared/hooks/useDebounce.tsx
+++ b/src/pages/Shared/hooks/useDebounce.tsx
@@ -1,0 +1,15 @@
+import { useState, useEffect } from 'react'
+
+export const useDebounce = (value: any, milliSeconds: number) => {
+	const [debouncedValue, setDebouncedValue] = useState(value);
+	useEffect(() => {
+		const timer = setTimeout(() => setDebouncedValue(value), milliSeconds || 1000);
+
+		return () => {
+			clearTimeout(timer);
+		};
+
+	}, [value, milliSeconds]);
+
+	return debouncedValue;
+};


### PR DESCRIPTION
- added a new debounce hook (using it to limit the amount of react re-renders as network resources continue to load onto a web page)
- refactored devtools/index.ts to improve upon performance.
- moved the event listener listening for local storage changes to the init req chain into its own react hook (previously it was inside of the fetchEvents hook
- also further reduced the amount of react re-renders relative to the req chain by removing logic around that from app context to inspectContext (set hooks were getting invoked in both contexts are only needed in one of the context files)