### PR TITLE
added pbjs version analyzer tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,9 @@
         "@types/doubleclick-gpt": "^2019111201.0.2",
         "@types/react-router-dom": "^5.3.2",
         "@types/requestidlecallback": "^0.3.4",
+        "html-react-parser": "^4.2.0",
         "lodash": "^4.17.21",
+        "moment": "^2.29.4",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-error-boundary": "^4.0.9",
@@ -29,7 +31,8 @@
         "react-loader-spinner": "^5.3.4",
         "react-router-dom": "^6.3.0",
         "react-window": "^1.8.6",
-        "semver": "^6.3.0"
+        "semver": "^6.3.0",
+        "showdown": "^2.1.0"
       },
       "devDependencies": {
         "@babel/core": "^7.15.8",
@@ -42,6 +45,7 @@
         "@types/react-dom": "^17.0.10",
         "@types/react-window": "^1.8.5",
         "@types/semver": "^7.3.10",
+        "@types/showdown": "^2.0.1",
         "@typescript-eslint/parser": "^4.33.0",
         "babel-eslint": "^10.1.0",
         "babel-loader": "^8.2.2",
@@ -2848,6 +2852,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/showdown": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/showdown/-/showdown-2.0.1.tgz",
+      "integrity": "sha512-xdnAw2nFqomkaL0QdtEk0t7yz26UkaVPl4v1pYJvtE1T0fmfQEH3JaxErEhGByEAl3zUZrkNBlneuJp0WJGqEA==",
+      "dev": true
+    },
     "node_modules/@types/sockjs": {
       "version": "0.3.33",
       "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.33.tgz",
@@ -4698,7 +4708,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6273,6 +6282,84 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/html-dom-parser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-4.0.0.tgz",
+      "integrity": "sha512-TUa3wIwi80f5NF8CVWzkopBVqVAtlawUzJoLwVLHns0XSJGynss4jiY0mTWpiDOsuyw+afP+ujjMgRh9CoZcXw==",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "htmlparser2": "9.0.0"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/htmlparser2": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.0.0.tgz",
+      "integrity": "sha512-uxbSI98wmFT/G4P2zXx4OVx04qWUmyFPrD2/CNepa2Zo3GPNaCaaxElDgwUrwYWkK1nr9fft0Ya8dws8coDLLQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
     "node_modules/html-entities": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
@@ -6318,6 +6405,34 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/html-react-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-4.2.0.tgz",
+      "integrity": "sha512-gzU55AS+FI6qD7XaKe5BLuLFM2Xw0/LodfMWZlxV9uOHe7LCD5Lukx/EgYuBI3c0kLu0XlgFXnSzO0qUUn3Vrg==",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "html-dom-parser": "4.0.0",
+        "react-property": "2.0.0",
+        "style-to-js": "1.1.3"
+      },
+      "peerDependencies": {
+        "react": "0.14 || 15 || 16 || 17 || 18"
+      }
+    },
+    "node_modules/html-react-parser/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
     "node_modules/html-webpack-plugin": {
@@ -6533,6 +6648,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
@@ -7408,6 +7528,14 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -8491,6 +8619,11 @@
         "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-property": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
+      "integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw=="
+    },
     "node_modules/react-router": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
@@ -9106,6 +9239,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/showdown": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
+      "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
+      "dependencies": {
+        "commander": "^9.0.0"
+      },
+      "bin": {
+        "showdown": "bin/showdown.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://www.paypal.me/tiviesantos"
+      }
+    },
+    "node_modules/showdown/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -9457,6 +9613,22 @@
       },
       "peerDependencies": {
         "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.3.tgz",
+      "integrity": "sha512-zKI5gN/zb7LS/Vm0eUwjmjrXWw8IMtyA8aPBJZdYiQTXj4+wQ3IucOLIOnF7zCHxvW8UhIGh/uZh/t9zEHXNTQ==",
+      "dependencies": {
+        "style-to-object": "0.4.1"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.1.tgz",
+      "integrity": "sha512-HFpbb5gr2ypci7Qw+IOhnP2zOU7e77b+rzM+wTzXzfi1PrtBCX0E7Pk4wL4iTLnhzZ+JgEGAhX81ebTg/aYjQw==",
+      "dependencies": {
+        "inline-style-parser": "0.1.1"
       }
     },
     "node_modules/styled-components": {
@@ -12618,6 +12790,12 @@
         "@types/node": "*"
       }
     },
+    "@types/showdown": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/showdown/-/showdown-2.0.1.tgz",
+      "integrity": "sha512-xdnAw2nFqomkaL0QdtEk0t7yz26UkaVPl4v1pYJvtE1T0fmfQEH3JaxErEhGByEAl3zUZrkNBlneuJp0WJGqEA==",
+      "dev": true
+    },
     "@types/sockjs": {
       "version": "0.3.33",
       "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.33.tgz",
@@ -14032,8 +14210,7 @@
     "domelementtype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
     },
     "domhandler": {
       "version": "4.3.1",
@@ -15230,6 +15407,61 @@
         }
       }
     },
+    "html-dom-parser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-4.0.0.tgz",
+      "integrity": "sha512-TUa3wIwi80f5NF8CVWzkopBVqVAtlawUzJoLwVLHns0XSJGynss4jiY0mTWpiDOsuyw+afP+ujjMgRh9CoZcXw==",
+      "requires": {
+        "domhandler": "5.0.3",
+        "htmlparser2": "9.0.0"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+          "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+          "requires": {
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.2",
+            "entities": "^4.2.0"
+          }
+        },
+        "domhandler": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+          "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+          "requires": {
+            "domelementtype": "^2.3.0"
+          }
+        },
+        "domutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+          "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+          "requires": {
+            "dom-serializer": "^2.0.0",
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.3"
+          }
+        },
+        "entities": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+          "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+        },
+        "htmlparser2": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.0.0.tgz",
+          "integrity": "sha512-uxbSI98wmFT/G4P2zXx4OVx04qWUmyFPrD2/CNepa2Zo3GPNaCaaxElDgwUrwYWkK1nr9fft0Ya8dws8coDLLQ==",
+          "requires": {
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.3",
+            "domutils": "^3.1.0",
+            "entities": "^4.5.0"
+          }
+        }
+      }
+    },
     "html-entities": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
@@ -15259,6 +15491,27 @@
         "param-case": "^3.0.4",
         "relateurl": "^0.2.7",
         "terser": "^5.10.0"
+      }
+    },
+    "html-react-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-4.2.0.tgz",
+      "integrity": "sha512-gzU55AS+FI6qD7XaKe5BLuLFM2Xw0/LodfMWZlxV9uOHe7LCD5Lukx/EgYuBI3c0kLu0XlgFXnSzO0qUUn3Vrg==",
+      "requires": {
+        "domhandler": "5.0.3",
+        "html-dom-parser": "4.0.0",
+        "react-property": "2.0.0",
+        "style-to-js": "1.1.3"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+          "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+          "requires": {
+            "domelementtype": "^2.3.0"
+          }
+        }
       }
     },
     "html-webpack-plugin": {
@@ -15408,6 +15661,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "inline-style-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -16066,6 +16324,11 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+    },
+    "moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "ms": {
       "version": "2.1.2",
@@ -16851,6 +17114,11 @@
         "styled-tools": "^1.7.2"
       }
     },
+    "react-property": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
+      "integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw=="
+    },
     "react-router": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
@@ -17334,6 +17602,21 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "showdown": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
+      "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
+      "requires": {
+        "commander": "^9.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "9.5.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+          "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="
+        }
+      }
+    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -17598,6 +17881,22 @@
       "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
       "dev": true,
       "requires": {}
+    },
+    "style-to-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.3.tgz",
+      "integrity": "sha512-zKI5gN/zb7LS/Vm0eUwjmjrXWw8IMtyA8aPBJZdYiQTXj4+wQ3IucOLIOnF7zCHxvW8UhIGh/uZh/t9zEHXNTQ==",
+      "requires": {
+        "style-to-object": "0.4.1"
+      }
+    },
+    "style-to-object": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.1.tgz",
+      "integrity": "sha512-HFpbb5gr2ypci7Qw+IOhnP2zOU7e77b+rzM+wTzXzfi1PrtBCX0E7Pk4wL4iTLnhzZ+JgEGAhX81ebTg/aYjQw==",
+      "requires": {
+        "inline-style-parser": "0.1.1"
+      }
     },
     "styled-components": {
       "version": "5.3.11",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "@types/doubleclick-gpt": "^2019111201.0.2",
     "@types/react-router-dom": "^5.3.2",
     "@types/requestidlecallback": "^0.3.4",
+    "html-react-parser": "^4.2.0",
     "lodash": "^4.17.21",
+    "moment": "^2.29.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-error-boundary": "^4.0.9",
@@ -33,7 +35,8 @@
     "react-loader-spinner": "^5.3.4",
     "react-router-dom": "^6.3.0",
     "react-window": "^1.8.6",
-    "semver": "^6.3.0"
+    "semver": "^6.3.0",
+    "showdown": "^2.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.15.8",
@@ -46,6 +49,7 @@
     "@types/react-dom": "^17.0.10",
     "@types/react-window": "^1.8.5",
     "@types/semver": "^7.3.10",
+    "@types/showdown": "^2.0.1",
     "@typescript-eslint/parser": "^4.33.0",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.2.2",

--- a/src/pages/Panel/components/NavBarComponent.tsx
+++ b/src/pages/Panel/components/NavBarComponent.tsx
@@ -25,6 +25,7 @@ import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined';
 import StateContext from '../../Shared/contexts/appStateContext';
 import { sendChromeTabsMessage } from '../../Shared/utils';
 import LinkIcon from '@mui/icons-material/Link';
+import DifferenceIcon from '@mui/icons-material/Difference';
 
 const RouterLink = ({ target, activeRoute, clickHandler, icon, label }: RouterLinkComponentProps): JSX.Element => (
   <Link to={target}>
@@ -137,7 +138,15 @@ const NavBarComponent = () => {
           activeRoute={activeRoute}
           clickHandler={() => handleRouteChange('/initiator')}
           icon={<LinkIcon />}
-          label="Netwok Inspector (alpha)"
+          label="Network Inspector"
+        />
+
+        <RouterLink
+          target="version"
+          activeRoute={activeRoute}
+          clickHandler={() => handleRouteChange('/version')}
+          icon={<DifferenceIcon />}
+          label="Version"
         />
 
       </Box>

--- a/src/pages/Shared/components/RoutesComponent.tsx
+++ b/src/pages/Shared/components/RoutesComponent.tsx
@@ -9,6 +9,7 @@ import ToolsComponent from './tools/ToolsComponent';
 import EventsComponent from './auctionDebugEvents/EventsComponent';
 import { Routes, Route } from 'react-router-dom';
 import InitiatorComponent from './initiator/InitiatorComponent';
+import PbjsVersionInfoComponent from './pbjsVersionInfo/PbjsVersionInfoComponent';
 const RoutesComponent = (): JSX.Element => {
   return (
     <Routes>
@@ -23,6 +24,7 @@ const RoutesComponent = (): JSX.Element => {
       <Route path="events" element={<EventsComponent />} />
       <Route path="events" element={<EventsComponent />} />
       <Route path="initiator" element={<InitiatorComponent />} />
+      <Route path="version" element={<PbjsVersionInfoComponent />} />
     </Routes>
   );
 };

--- a/src/pages/Shared/components/adUnits/AdUnitsHeader.tsx
+++ b/src/pages/Shared/components/adUnits/AdUnitsHeader.tsx
@@ -3,6 +3,7 @@ import Typography from '@mui/material/Typography';
 import Paper from '@mui/material/Paper';
 import Grid from '@mui/material/Grid';
 import AppStateContext from '../../contexts/appStateContext';
+import PbjsVersionInfoPopOver from '../pbjsVersionInfo/PbjsVersionInfoPopOver';
 import EventsPopOver from '../auctionDebugEvents/EventsPopOver';
 import { conditionalPluralization } from '../../utils';
 
@@ -21,11 +22,13 @@ const HeaderGridItem = ({ children, onClick }: HeaderGridItemProps): JSX.Element
 
 const AdUnitsHeaderComponent = (): JSX.Element => {
   const [eventsPopUpOpen, setEventsPopUpOpen] = useState<boolean>(false);
+  const [pbjsVersionPopUpOpen, setPbjsVersionPopUpOpen] = useState<boolean>(false);
   const { allBidResponseEvents, prebid, allNoBidEvents, allBidderEvents, allAdUnitCodes, events } = useContext(AppStateContext);
   if (!prebid) return null;
   return (
     <>
-      <HeaderGridItem>{`Version: ${prebid.version}`}</HeaderGridItem>
+      <HeaderGridItem onClick={() => setPbjsVersionPopUpOpen(true)}><div style={{cursor: "pointer"}}>{`Version: ${prebid.version}`}</div></HeaderGridItem>
+      <PbjsVersionInfoPopOver pbjsVersionPopUpOpen={pbjsVersionPopUpOpen} setPbjsVersionPopUpOpen={setPbjsVersionPopUpOpen} />
 
       <HeaderGridItem>{`Timeout: ${prebid.config?.bidderTimeout}`}</HeaderGridItem>
 
@@ -37,7 +40,8 @@ const AdUnitsHeaderComponent = (): JSX.Element => {
 
       <HeaderGridItem>{`NoBid${conditionalPluralization(allNoBidEvents)}: ${allNoBidEvents.length}`}</HeaderGridItem>
 
-      <HeaderGridItem onClick={() => setEventsPopUpOpen(true)}>{`Event${conditionalPluralization(events)}: ${events?.length}`}</HeaderGridItem>
+      <HeaderGridItem onClick={() => setEventsPopUpOpen(true)}>
+        <div style={{cursor: "pointer"}}>{`Event${conditionalPluralization(events)}: ${events?.length}`}</div></HeaderGridItem>
       <EventsPopOver eventsPopUpOpen={eventsPopUpOpen} setEventsPopUpOpen={setEventsPopUpOpen} />
     </>
   );

--- a/src/pages/Shared/components/pbjsVersionInfo/PbjsVersionInfoComponent.tsx
+++ b/src/pages/Shared/components/pbjsVersionInfo/PbjsVersionInfoComponent.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Grid from '@mui/material/Grid';
+import PbjsVersionInfoContent from './PbjsVersionInfoContent';
+import { Paper } from '@mui/material';
+const PbjsVersionInfoComponent = ({ close }: PbjsVersionInfoComponentProps): JSX.Element => {
+  return (
+    <Grid container spacing={1} sx={{ p: 0.5 }}>
+      <Grid item xs={12}>
+        <Paper>
+          <Grid container spacing={1} sx={{ p: 0.5 }}>
+            <PbjsVersionInfoContent close={close}></PbjsVersionInfoContent>
+          </Grid>
+        </Paper>
+      </Grid>
+    </Grid>
+  );
+};
+interface PbjsVersionInfoComponentProps {
+  close?: () => void;
+}
+
+export default PbjsVersionInfoComponent;

--- a/src/pages/Shared/components/pbjsVersionInfo/PbjsVersionInfoContent.css
+++ b/src/pages/Shared/components/pbjsVersionInfo/PbjsVersionInfoContent.css
@@ -1,0 +1,26 @@
+.MuiGrid-root.MuiGrid-item.MuiGrid-grid-xs-7.version-info__body.css-1ys5d6u-MuiGrid-root {
+  margin: auto;
+}
+
+.title__wrapper {
+  text-align: center;
+}
+
+.title__wrapper .sub-title__wrapper {
+  text-align: left;
+}
+
+.changelog__link {
+  text-align: center;
+  margin-top: 30px;
+  color: #ff6f00;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.pbjs-version-info__loader-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/pages/Shared/components/pbjsVersionInfo/PbjsVersionInfoContent.tsx
+++ b/src/pages/Shared/components/pbjsVersionInfo/PbjsVersionInfoContent.tsx
@@ -1,0 +1,339 @@
+import React, { useContext, useState } from 'react';
+import Grid from '@mui/material/Grid';
+import IconButton from '@mui/material/IconButton';
+import Close from '@mui/icons-material/Close';
+import AppStateContext from '../../contexts/appStateContext';
+import showdown from 'showdown';
+import moment from 'moment';
+import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import parse from 'html-react-parser';
+import { Bars } from 'react-loader-spinner';
+import './PbjsVersionInfoContent.css';
+
+const converter = new showdown.Converter();
+
+const PbjsVersionInfoContent = ({ close }: PbjsVersionInfoContentProps): JSX.Element => {
+  const { prebid, prebidReleaseInfo, setPrebidReleaseInfo } = useContext(AppStateContext);
+  const [showChangeLog, setShowChangeLog] = useState<boolean>(false);
+
+  const msToTime = (ms: number) => {
+    let minutes = (ms / (1000 * 60)).toFixed(1);
+    let hours = (ms / (1000 * 60 * 60)).toFixed(1);
+    let days = (ms / (1000 * 60 * 60 * 24)).toFixed(1);
+    let months = (ms / (1000 * 60 * 60 * 24 * 30)).toFixed(1);
+    let years = (ms / (1000 * 60 * 60 * 24 * 365)).toFixed(1);
+    let text = '';
+
+    if (Number(years) >= 1) {
+      text = `${years} year${Number(years) > 1 ? 's' : ''}, ${months} month${Number(months) > 1 ? 's' : ''} and ${days} day${
+        Number(days) > 1 ? 's' : ''
+      }`;
+    } else if (Number(months) >= 1) {
+      text = `${months} month${Number(months) > 1 ? 's' : ''} and ${days} day${Number(days) > 1 ? 's' : ''}`;
+    } else {
+      text = `${days} day${Number(days) > 1 ? 's' : ''}`;
+    }
+
+    return { years, months, days, hours, minutes, text };
+  };
+
+  const isCachedReleaseDataExpired = (cachedData: string) => {
+    let result = false;
+
+    if (Object.keys(cachedData).length > 0) {
+      const data = JSON.parse(cachedData);
+      const cachedTime = data[0].cached_at;
+      const currentTime = Date.now();
+      const differenceInMilliseconds = Math.round(currentTime - cachedTime);
+      const timeElapsed = msToTime(differenceInMilliseconds);
+      
+      if (Number(timeElapsed.days) >= 1) {
+        result = true;
+        console.log('cached data is expired, refreshing data from github');
+      }
+
+      console.log(timeElapsed);
+    }
+
+    return result;
+  };
+
+  const toggleChangeLog = () => {
+    setShowChangeLog(!showChangeLog)
+  };
+
+  const formatDate = (date: string) => {
+    const dateObj = new Date(date);
+    const month = dateObj.toLocaleString('default', { month: 'long' });
+    const day = dateObj.toLocaleString('default', { day: 'numeric' });
+    const year = dateObj.toLocaleString('default', { year: 'numeric' });
+    return `${month} ${day}, ${year}`;
+  };
+
+  const processReleaseData = (releaseData: any[], trackingData: TrackingDataProps, page: number) => {
+    const dataForCurrentUsedRelease = releaseData.find((release: ReleaseProps) => {
+      const text = release.body;
+      const html = converter.makeHtml(text);
+      const doc = new DOMParser().parseFromString(html, 'text/html');
+      release.doc = doc;
+      trackingData.releasesSinceInstalledVersion.push(release);
+
+      const newFeaturesEl = doc.getElementById('newfeatures');
+      const maintenanceEl = doc.getElementById('maintenance');
+      const bugfixesEl = doc.getElementById('bugfixes');
+      const newFeaturesCount = newFeaturesEl?.nextElementSibling?.children.length;
+      const maintenanceCount = maintenanceEl?.nextElementSibling?.children.length;
+      const bugfixesCount = bugfixesEl?.nextElementSibling?.children.length;
+
+      if (newFeaturesCount) {
+        trackingData.totalNewFeaturesCount = trackingData.totalNewFeaturesCount + newFeaturesCount;
+      }
+
+      if (maintenanceCount) {
+        trackingData.totalMaintenanceCount = trackingData.totalMaintenanceCount + maintenanceCount;
+      }
+
+      if (bugfixesCount) {
+        trackingData.totalBugfixesCount = trackingData.totalBugfixesCount + bugfixesCount;
+      }
+
+      return `v${release.tag_name}` === prebid.version;
+    });
+
+    if (dataForCurrentUsedRelease) {
+      const oldVersionPublishedAtDate = dataForCurrentUsedRelease.published_at;
+      const currentDate = new Date();
+      const differenceInMilliseconds = Math.round(currentDate.valueOf() - Date.parse(oldVersionPublishedAtDate));
+      trackingData.timeElapsed = msToTime(differenceInMilliseconds);
+
+      const processedReleaseInfoObj = {
+        latestVersion: trackingData.releasesSinceInstalledVersion[0].tag_name,
+        installedVersion: prebid.version,
+        installedVersionPublishedAt: oldVersionPublishedAtDate,
+        timeElapsedSinceLatestVersion: trackingData.timeElapsed,
+        featureCountSinceInstalledVersion: trackingData.totalNewFeaturesCount,
+        maintenanceCountSinceInstalledVersion: trackingData.totalMaintenanceCount,
+        bugfixCountSinceInstalledVersion: trackingData.totalBugfixesCount,
+        releasesSinceInstalledVersion: trackingData.releasesSinceInstalledVersion
+      };
+
+      setPrebidReleaseInfo(processedReleaseInfoObj);
+      
+      if (page) {
+        console.log('setting pbjsReleasesData in storage: ', trackingData.releasesSinceInstalledVersion);
+        trackingData.releasesSinceInstalledVersion[0].cached_at = Date.now();
+        chrome.storage.local.set({ 'pbjsReleasesData': JSON.stringify(trackingData.releasesSinceInstalledVersion) });
+      }
+    } else {
+      if (page && releaseData.length === 100) {
+        fetchReleaseInfo(page + 1, trackingData);
+      } else {
+        console.log('oops, the current version of PBJS is not in the release data');
+      }
+    }
+  };
+
+  const fetchReleaseInfo = async (page: number, trackingData: any) => {
+    console.log('calling github: ', `https://api.github.com/repos/prebid/Prebid.js/releases?per_page=100&page=${page}&owner=prebid&repo=Prebid.js`);
+    const response = await fetch(`https://api.github.com/repos/prebid/Prebid.js/releases?per_page=100&page=${page}&owner=prebid&repo=Prebid.js`);
+
+    if (!response.ok) {
+      const message = `An error has occured: ${response.status}`;
+      throw new Error(message);
+    }
+
+    const releaseData = await response.json();
+
+    processReleaseData(releaseData, trackingData, page);
+  };
+
+  if (
+    prebid &&
+    prebid.version &&
+    Object.keys(prebidReleaseInfo).length === 0
+  ) {
+    try {
+      let dataToTrackOverIterations: TrackingDataProps = {
+        totalNewFeaturesCount: 0,
+        totalMaintenanceCount: 0,
+        totalBugfixesCount: 0,
+        timeElapsed: { text: '', years: '', months: '', days: '', hours: '', minutes: '' },
+        releasesSinceInstalledVersion: []
+      };
+
+      chrome.storage.local.get('pbjsReleasesData', (result) => {
+        if (result.pbjsReleasesData && !isCachedReleaseDataExpired(result.pbjsReleasesData)) {
+          console.log('using pbjsReleasesData from storage: ', result);
+          // setPrebidReleaseInfo(JSON.parse(result.pbjsReleasesData));
+          processReleaseData(JSON.parse(result.pbjsReleasesData), dataToTrackOverIterations, 0);
+        } else {
+          console.log('calling the github api for pbjsReleasesData ');
+          fetchReleaseInfo(1, dataToTrackOverIterations);
+        }
+      });
+    } catch (error) {
+      console.error('Failed to fetch data for PBJS releases: ', error);
+    }
+  }
+
+  return (
+    <React.Fragment>
+      {close && (
+        <Grid
+          item
+          sx={{
+            display: 'flex',
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            alignItems: 'flex-end',
+            color: 'text.secondary',
+          }}
+          xs={12}
+        >
+          <IconButton sx={{ p: 0 }} onClick={() => close()}>
+            <Close sx={{ fontSize: 14 }} />
+          </IconButton>
+        </Grid>
+      )}
+      <Grid className="version-info__body" item xs={7}>
+        {Object.keys(prebidReleaseInfo).length > 0 ? (
+          <>
+            <div className="title__wrapper">
+              <div className="sub-title-main__wrapper">
+                {`v${prebidReleaseInfo.latestVersion}` === prebidReleaseInfo.installedVersion
+                  ? (
+                      <>
+                        <CheckCircleOutlineIcon color="primary" />
+                        <h4>You are using the latest version of Prebid.js!</h4>
+                      </>
+                    )
+                  : (
+                      <>
+                        <WarningAmberOutlinedIcon color="secondary" />
+                        <h4>Warning: Old version of Prebid.js detected..</h4>
+                      </>
+                    )
+                }
+              </div>
+              <div className="sub-title__wrapper">
+                <p>
+                  <strong>Latest PBJS Version:</strong> v{prebidReleaseInfo.latestVersion}
+                </p>
+                <p>
+                  <strong>Installed PBJS Version:</strong> {prebidReleaseInfo.installedVersion}
+                </p>
+              </div>
+            </div>
+            <div className="content__wrapper">
+              {`v${prebidReleaseInfo.latestVersion}` === prebidReleaseInfo.installedVersion
+                ? (
+                      <>
+                        <p>
+                          <strong>Details:</strong> For more information about Prebid.js releases, please visit the following link: <a style={{color: "#ff6f00"}} href="https://github.com/prebid/Prebid.js/releases" target="_blank" rel="noreferrer">https://github.com/prebid/Prebid.js/releases</a>
+                        </p>
+                      </>
+                  )
+                : (
+                    <>
+                      <p>
+                        <strong>Details:</strong> {prebidReleaseInfo.installedVersion} was released {moment(prebidReleaseInfo.installedVersionPublishedAt).fromNow()}. Approximately, the following number of updates have been pushed since it's release:
+                      </p>
+                      <ul className="updates__wrapper">
+                        <li>
+                          <strong>New Features:</strong> {prebidReleaseInfo.featureCountSinceInstalledVersion}
+                        </li>
+                        <li>
+                          <strong>Maintenance Updates:</strong> {prebidReleaseInfo.maintenanceCountSinceInstalledVersion}
+                        </li>
+                        <li>
+                          <strong>Bug Fixes:</strong> {prebidReleaseInfo.bugfixCountSinceInstalledVersion}
+                        </li>
+                      </ul>
+                      <p className="changelog__link" onClick={toggleChangeLog}>
+                        View Full Release Changelog Since {prebidReleaseInfo.installedVersion}
+                      </p>
+                    </>
+                  )
+              }
+            </div>
+            {showChangeLog && prebidReleaseInfo.releasesSinceInstalledVersion.map((version: VersionProps) => (
+              <>
+                <hr />
+                <p>
+                  <strong>Name:</strong> {version.name}
+                </p>
+                <p>
+                  <strong>Published:</strong> {formatDate(version.published_at)}
+                </p>
+                <p>
+                  <strong>URL:</strong> <a style={{color: "#ff6f00"}} href={version.html_url} target='_blank' rel="noreferrer">{version.html_url}</a>
+                </p>
+                <p>
+                  <strong>Description:</strong> {parse(version.doc.body.innerHTML)}
+                </p>
+              </>
+            ))}
+          </>
+        )
+        : (
+            <div className="pbjs-version-info__loader-wrapper">
+              <p>Attempting to fetch data about PBJS releases..</p>
+              <div className="loader">
+                <Bars
+                  height="80"
+                  width="50"
+                  color="#ff6f00"
+                  ariaLabel="bars-loading"
+                  wrapperStyle={{}}
+                  wrapperClass=""
+                  visible={true}
+                />
+              </div>
+            </div>
+          )
+        }
+      </Grid>
+    </React.Fragment>
+  );
+};
+
+interface PbjsVersionInfoContentProps {
+  close?: () => void | undefined;
+}
+
+interface ReleaseProps {
+  doc: Document;
+  body: string;
+  name: string;
+  tag_name: string;
+  cached_at: number;
+}
+
+interface VersionProps {
+  name: boolean | React.ReactChild | React.ReactFragment | React.ReactPortal;
+  published_at: string;
+  html_url: string;
+  doc: {
+    body: {
+      innerHTML: string;
+    };
+  };
+}
+
+interface TrackingDataProps {
+  releasesSinceInstalledVersion: ReleaseProps[];
+  totalNewFeaturesCount: number;
+  totalMaintenanceCount: number;
+  totalBugfixesCount: number;
+  timeElapsed: {
+    years: string;
+    months: string;
+    days: string;
+    hours: string;
+    minutes: string;
+    text: string;
+  };
+}
+
+export default PbjsVersionInfoContent;

--- a/src/pages/Shared/components/pbjsVersionInfo/PbjsVersionInfoPopOver.tsx
+++ b/src/pages/Shared/components/pbjsVersionInfo/PbjsVersionInfoPopOver.tsx
@@ -1,0 +1,25 @@
+import React, { useContext } from 'react';
+import Popover from '@mui/material/Popover';
+import StateContext from '../../contexts/appStateContext';
+import PbjsVersionInfoComponent from './PbjsVersionInfoComponent';
+
+const PbjsVersionInfoPopOver = ({ pbjsVersionPopUpOpen, setPbjsVersionPopUpOpen }: { pbjsVersionPopUpOpen: boolean; setPbjsVersionPopUpOpen: Function }): JSX.Element => {
+  const { prebid } = useContext(StateContext);
+  if (!prebid) return null;
+  return (
+    <Popover
+      open={pbjsVersionPopUpOpen}
+      anchorReference="anchorPosition"
+      anchorPosition={{ top: 1, left: 1 }}
+      anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
+      transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+      onClose={() => setPbjsVersionPopUpOpen(false)}
+      PaperProps={{ style: { width: '100%', padding: 1 } }}
+    >
+      <PbjsVersionInfoComponent close={() => setPbjsVersionPopUpOpen(false)} />
+    </Popover>
+  );
+};
+
+export default PbjsVersionInfoPopOver;
+

--- a/src/pages/Shared/contexts/appStateContext.tsx
+++ b/src/pages/Shared/contexts/appStateContext.tsx
@@ -33,6 +33,8 @@ const AppStateContext = React.createContext<AppState>({
   setIsRefresh: () => {},
   initDataLoaded: false,
   setInitDataLoaded: () => {},
+  prebidReleaseInfo: {},
+  setPrebidReleaseInfo: () => {},
 });
 
 export const StateContextProvider = ({ children }: StateContextProviderProps) => {
@@ -53,11 +55,13 @@ export const StateContextProvider = ({ children }: StateContextProviderProps) =>
   const [initiatorOutput, setInitiatorOutput] = useState<any>({});
   const [isRefresh, setIsRefresh] = useState<boolean>(false);
   const [initDataLoaded, setInitDataLoaded] = useState<boolean>(false);
+  const [prebidReleaseInfo, setPrebidReleaseInfo] = useState<any>({});
 
   useEffect(() => {
     if (pbjsNamespace === undefined && prebids && Object.keys(prebids).length > 0) {
       const defaultNameSpaceIndex = Object.keys(prebids).findIndex((el) => el === 'pbjs');
       const newValue = defaultNameSpaceIndex > -1 ? Object.keys(prebids)[defaultNameSpaceIndex] : Object.keys(prebids)[0];
+
       setPbjsNamespace(newValue);
     }
   }, [pbjsNamespace, prebids, setPbjsNamespace]);
@@ -119,6 +123,8 @@ export const StateContextProvider = ({ children }: StateContextProviderProps) =>
     setIsRefresh,
     initDataLoaded,
     setInitDataLoaded,
+    prebidReleaseInfo,
+    setPrebidReleaseInfo,
   };
 
   return <AppStateContext.Provider value={contextValue}>{children}</AppStateContext.Provider>;
@@ -149,6 +155,16 @@ interface AppState {
   setIsRefresh: React.Dispatch<React.SetStateAction<boolean>>;
   initDataLoaded: boolean;
   setInitDataLoaded: React.Dispatch<React.SetStateAction<boolean>>;
+  prebidReleaseInfo: {
+    latestVersion?: string;
+    installedVersion?: string;
+    installedVersionPublishedAt?: string;
+    featureCountSinceInstalledVersion?: number;
+    maintenanceCountSinceInstalledVersion?: number;
+    bugfixCountSinceInstalledVersion?: number;
+    releasesSinceInstalledVersion?: any[];
+  };
+  setPrebidReleaseInfo: React.Dispatch<React.SetStateAction<any>>;
 }
 
 interface StateContextProviderProps {


### PR DESCRIPTION
Relates to https://github.com/prebid/professor-prebid/issues/64

Summary:
This PR includes code for a new tool in Professor Prebid that will analyze and gather information about the currently used PBJS version on a webpage.  It uses the GitHub API to gather info about releases from the Prebid.js repo (calls to the API are minimal, a call is made initially and cached in local storage, then once every 24 hours the data in local storage will be refreshed by another call).  Other features for this include:

- Stating what is the latest Prebid release version is
- Display how many months/weeks/days old the current setup is compared to the latest Prebid release
- An approximate count of all of the new features, maintenance updates and bug fixes that have been released since the currently running version are displayed.
- Also a descriptive list of all of the new features, maintenance updates and bug fixes that have been released since the currently running version can also be displayed by clicking on a link to toggle them in and out of view