### PR TITLE
Update to pbjs version tool

### DIFF
--- a/src/pages/Shared/components/pbjsVersionInfo/PbjsVersionInfoContent.tsx
+++ b/src/pages/Shared/components/pbjsVersionInfo/PbjsVersionInfoContent.tsx
@@ -129,7 +129,17 @@ const PbjsVersionInfoContent = ({ close }: PbjsVersionInfoContentProps): JSX.Ele
       if (page && releaseData.length === 100) {
         fetchReleaseInfo(page + 1, trackingData);
       } else {
-        console.log('oops, the current version of PBJS is not in the release data');
+        if (!page) {
+          fetchReleaseInfo(1, {
+            totalNewFeaturesCount: 0,
+            totalMaintenanceCount: 0,
+            totalBugfixesCount: 0,
+            timeElapsed: { text: '', years: '', months: '', days: '', hours: '', minutes: '' },
+            releasesSinceInstalledVersion: []
+          });
+        } else {
+          console.log('Oops, something went wrong. No release data for the currently installed PBJS version was able to be found.');
+        }
       }
     }
   };
@@ -308,6 +318,7 @@ interface ReleaseProps {
   name: string;
   tag_name: string;
   cached_at: number;
+  hostname: string;
 }
 
 interface VersionProps {

--- a/src/pages/Shared/components/pbjsVersionInfo/PbjsVersionInfoContent.tsx
+++ b/src/pages/Shared/components/pbjsVersionInfo/PbjsVersionInfoContent.tsx
@@ -318,7 +318,6 @@ interface ReleaseProps {
   name: string;
   tag_name: string;
   cached_at: number;
-  hostname: string;
 }
 
 interface VersionProps {


### PR DESCRIPTION
- edge case bug fix for if a user navigates across multiple different sites that use prebid and then interact with the pbjs version tool on professor prebid on each site.. now the correct pbjs version data will be displayed each time.