### PR TITLE
Adunits and Timeline Sections - Added bidderRequests and topics to JSON modals

### DIFF
--- a/src/pages/Content/scripts/prebid.ts
+++ b/src/pages/Content/scripts/prebid.ts
@@ -247,6 +247,7 @@ export interface IPrebidBid {
   adUnitCode: string;
   adUrl: string;
   adserverTargeting: any;
+  bidId: string;
   hb_adid: string;
   hb_adomain: string;
   hb_bidder: string;

--- a/src/pages/Popup/components/timeline/BidderBarComponent.tsx
+++ b/src/pages/Popup/components/timeline/BidderBarComponent.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useContext } from 'react';
 import JSONViewerComponent from '../../../Shared/components/JSONViewerComponent';
 import { IPrebidAuctionEndEventData, IPrebidBidderRequest } from '../../../Content/scripts/prebid';
 import ListItem from '@mui/material/ListItem';
 import Typography from '@mui/material/Typography';
 import Popover from '@mui/material/Popover';
+import StateContext from '../../../Shared/contexts/appStateContext';
 
 const getNearestGridBarElement = (input: number, gridRef: React.MutableRefObject<HTMLElement>) => {
   const allGridBarsCollection = gridRef?.current?.children;
@@ -27,6 +28,7 @@ const getListItemStyle = (isTimeOut: boolean, width: number, left: number) => ({
 });
 
 const PopoverWithJSONViewer = ({ anchorEl, bidderRequest, open, handlePopoverOpenClose }: IPopoverWithJSONViewerProps) => {
+  const { topics } = useContext(StateContext);
   return (
     <Popover
       open={open}
@@ -38,7 +40,7 @@ const PopoverWithJSONViewer = ({ anchorEl, bidderRequest, open, handlePopoverOpe
       onClick={(e) => e.stopPropagation()}
     >
       <JSONViewerComponent
-        src={bidderRequest}
+        src={{ ...bidderRequest, topics }}
         name={false}
         collapsed={3}
         displayObjectSize={false}

--- a/src/pages/Shared/components/adUnits/cards/AdUnitCard.tsx
+++ b/src/pages/Shared/components/adUnits/cards/AdUnitCard.tsx
@@ -4,6 +4,7 @@ import {
   IPrebidAdUnit,
   IPrebidBidWonEventData,
   IPrebidAdRenderSucceededEventData,
+  IPrebidBidRequestedEventData,
 } from '../../../../Content/scripts/prebid';
 import Typography from '@mui/material/Typography';
 import Card from '@mui/material/Card';
@@ -22,6 +23,7 @@ const AdUnitCard = ({ adUnit, adUnit: { code: adUnitCode } }: { adUnit: IPrebidA
   const { mediaTypes } = adUnit;
   const [winningBids, setAuctionsWinningBids] = React.useState<IPrebidBidWonEventData[]>([]);
   const [auctionsBidsReceived, setAuctionBidsReceived] = React.useState<IPrebidBidWonEventData[]>([]);
+  const [auctionsBidsRequested, setAuctionsBidsRequested] = React.useState<IPrebidBidRequestedEventData[]>([]);
   const [auctionsAdsRendered, setAuctionsAdsRendered] = React.useState<IPrebidAdRenderSucceededEventData[]>([]);
 
   useEffect(() => {
@@ -39,6 +41,10 @@ const AdUnitCard = ({ adUnit, adUnit: { code: adUnitCode } }: { adUnit: IPrebidA
       ({ eventType, args: { auctionId } }) => eventType === 'bidResponse' && auctionId === latestAuctionId
     );
 
+    const auctionsBidsRequested = (events as IPrebidBidRequestedEventData[]).filter(
+      ({ eventType, args: { auctionId } }) => eventType === 'bidRequested' && auctionId === latestAuctionId
+    );
+
     const auctionsAdsRendered = (events as IPrebidAdRenderSucceededEventData[]).filter(
       ({
         eventType,
@@ -50,6 +56,7 @@ const AdUnitCard = ({ adUnit, adUnit: { code: adUnitCode } }: { adUnit: IPrebidA
 
     setAuctionsWinningBids(auctionsWinningBids);
     setAuctionBidsReceived(auctionsBidsReceived);
+    setAuctionsBidsRequested(auctionsBidsRequested);
     setAuctionsAdsRendered(auctionsAdsRendered);
   }, [events]);
 
@@ -137,6 +144,11 @@ const AdUnitCard = ({ adUnit, adUnit: { code: adUnitCode } }: { adUnit: IPrebidA
                 bidReceived.args.bidder === bidder &&
                 adUnit.sizes?.map((size) => `${size[0]}x${size[1]}`)?.includes(bidReceived?.args?.size)
             );
+            const bidRequested = auctionsBidsRequested.find(
+              (bidReq) =>
+                bidReq.args.bidderCode === bidder &&
+                bidReq.args.bids.find((bid) => bid.adUnitCode === adUnit.code)
+            );
             const isWinner = winningBids.some(
               (winningBid) =>
                 winningBid.args.adUnitCode === adUnit.code &&
@@ -153,7 +165,7 @@ const AdUnitCard = ({ adUnit, adUnit: { code: adUnitCode } }: { adUnit: IPrebidA
               ? `${bidder} (${Number(bidReceived?.args.cpm).toFixed(2)} ${bidReceived?.args.currency})`
               : `${bidder}`;
             return (
-              <BidChipComponent input={arr[index]} label={label} key={index} isWinner={isWinner} bidReceived={bidReceived} isRendered={isRendered} />
+              <BidChipComponent input={arr[index]} label={label} key={index} isWinner={isWinner} bidRequested={bidRequested} bidReceived={bidReceived} isRendered={isRendered} />
             );
           })}
         </Stack>

--- a/src/pages/Shared/components/adUnits/chips/BidChipComponent.tsx
+++ b/src/pages/Shared/components/adUnits/chips/BidChipComponent.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { IPrebidBidWonEventData, IPrebidBid } from '../../../../Content/scripts/prebid';
+import React, { useContext } from 'react';
+import { IPrebidBidWonEventData, IPrebidBid, IPrebidBidRequestedEventData } from '../../../../Content/scripts/prebid';
+import StateContext from '../../../contexts/appStateContext';
 import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
 import JSONViewerComponent from '../../JSONViewerComponent';
@@ -7,7 +8,8 @@ import Popover from '@mui/material/Popover';
 import GavelOutlinedIcon from '@mui/icons-material/GavelOutlined';
 import PictureInPictureOutlinedIcon from '@mui/icons-material/PictureInPictureOutlined';
 
-const BidChipComponent = ({ input, label, isWinner, bidReceived, isRendered }: IBidChipComponentProps): JSX.Element => {
+const BidChipComponent = ({ input, label, isWinner, bidReceived, bidRequested, isRendered }: IBidChipComponentProps): JSX.Element => {
+  const { topics } = useContext(StateContext);
   const [popUpOpen, setPopUpOpen] = React.useState<boolean>(false);
 
   return (
@@ -34,7 +36,7 @@ const BidChipComponent = ({ input, label, isWinner, bidReceived, isRendered }: I
         onClose={() => setPopUpOpen(false)}
       >
         <JSONViewerComponent
-          src={{ input: input, bidResponse: bidReceived || 'noBid' }}
+          src={{ input: input, bidderRequest: bidRequested, bidResponse: bidReceived || 'noBid', topics }}
           name={false}
           collapsed={3}
           displayObjectSize={false}
@@ -54,6 +56,7 @@ interface IBidChipComponentProps {
   input: IPrebidBid;
   label: string;
   isWinner: boolean;
+  bidRequested:IPrebidBidRequestedEventData | undefined; 
   bidReceived: IPrebidBidWonEventData | undefined;
   isRendered: boolean;
 }

--- a/src/pages/Shared/components/adUnits/grid/tiles/BiddersTile.tsx
+++ b/src/pages/Shared/components/adUnits/grid/tiles/BiddersTile.tsx
@@ -22,7 +22,7 @@ const matchesSizes = (bidEvent: IPrebidBidWonEventData, adUnit: IPrebidAdUnit): 
 };
 
 const BiddersTile = ({ adUnit, adUnit: { code: adUnitCode } }: IBiddersTileProps): JSX.Element => {
-  const { allWinningBids, allBidResponseEvents, adsRendered, isPanel } = useContext(StateContext);
+  const { allWinningBids, allBidResponseEvents, allBidRequestedEvents, adsRendered, isPanel } = useContext(StateContext);
   const [expanded, setExpanded] = React.useState(false);
 
   const handleExpandClick = () => {
@@ -77,6 +77,12 @@ const BiddersTile = ({ adUnit, adUnit: { code: adUnitCode } }: IBiddersTileProps
                         bidReceived.args?.adUnitCode === adUnitCode && bidReceived.args.bidder === bidder && matchesSizes(bidReceived, adUnit)
                     );
 
+                    const bidRequested = allBidRequestedEvents.find(
+                      (bidReq) =>
+                        bidReq.args.bidderCode === bidder &&
+                        bidReq.args.bids.find((bid) => bid.adUnitCode === adUnitCode)
+                    );
+
                     const isWinner = allWinningBids.some(
                       (winningBid) =>
                         winningBid.args.adUnitCode === adUnitCode && winningBid.args.bidder === bidder && matchesSizes(winningBid, adUnit)
@@ -96,6 +102,7 @@ const BiddersTile = ({ adUnit, adUnit: { code: adUnitCode } }: IBiddersTileProps
                         label={label}
                         key={index}
                         isWinner={isWinner}
+                        bidRequested={bidRequested}
                         bidReceived={bidReceived}
                         isRendered={isRendered}
                       />


### PR DESCRIPTION
ADUNITS section
- added bidderRequests to the JSON modal popup when a user clicks on a bid under the "bidders" column.
- also added topics present in a user's browser for a specific url (if any are present), when a user clicks on a bid under the "bidders" column.  if none are present topics will be sent as an empty array.

TIMELINE section
- added topics within the json modal popup when a user clicks on an ssp in the timeline section as well (bidderRequests are present here as well, they were there prior to this PR)